### PR TITLE
Fix pulling from a custom registry

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var pull = function (image, opts, cb) {
   image = parse(image)
   if (!image) throw new Error('Invalid image')
 
-  var request = docker({host: opts.host, version: opts.version || 'v1.15'})
+  var request = docker({host: opts.host, version: opts.version || 'v1.21'})
   var that = new events.EventEmitter()
   var layers = {}
   var progress = {}
@@ -42,11 +42,20 @@ var pull = function (image, opts, cb) {
     cb()
   }
 
+  var fromImage = image.repository
+
+  if (image.namespace) {
+    fromImage = image.namespace + '/' + fromImage
+  }
+
+  if (image.registry) {
+    fromImage = image.registry + '/' + fromImage
+  }
+
   var post = request.post('/images/create', {
     qs: {
-      fromImage: (image.namespace ? image.namespace + '/' : '') + image.repository,
-      tag: image.tag || 'latest',
-      registry: image.registry || ''
+      fromImage: fromImage,
+      tag: image.tag || 'latest'
     },
     headers: {
       'X-Registry-Auth': {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var pull = function (image, opts, cb) {
   image = parse(image)
   if (!image) throw new Error('Invalid image')
 
-  var request = docker(opts.host, {version: opts.version || 'v1.15'})
+  var request = docker({host: opts.host, version: opts.version || 'v1.15'})
   var that = new events.EventEmitter()
   var layers = {}
   var progress = {}


### PR DESCRIPTION
Since Engine API [1.21](https://github.com/moby/moby/blob/v1.9.1/docs/reference/api/docker_remote_api_v1.21.md#create-an-image) (compare against [1.20](https://github.com/moby/moby/blob/v1.9.1/docs/reference/api/docker_remote_api_v1.20.md#create-an-image)), the `POST /images/create` route no longer takes a `registry` query parameter:

```
POST /v1.20/images/create?fromImage=prebuild%2Flinux-armv6&tag=1&registry=ghcr.io
```

Instead a custom registry must be provided as part of the `fromImage` query parameter:

```
POST /v1.21/images/create?fromImage=ghcr.io%2Fprebuild%2Flinux-armv6&tag=1
```

Without this, pulling fails with a `manifest unknown` error:

```
Error: manifest for prebuild/linux-armv6:1 not found: manifest unknown: manifest unknown
    at D:\Projecten\GitHub\Level\leveldown\node_modules\docker-remote-api\index.js:59:15
```

Strangely, with 1.15 (the default version used here) I get the same error. Which led me to a separate bug, namely that `opts.version` isn't forwarded to [`docker-remote-api`](https://github.com/mafintosh/docker-remote-api). That's fixed by f9f8ec7. Unfortunately it doesn't fix the `manifest unknown` error.

So I instead propose to bump the default Engine API version from 1.15 to 1.21 and update query parameters accordingly. That's done in b7b315c.